### PR TITLE
戦績登録するたびにrecordsを取得しないようにする

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="header">
     <p class="page-title">{{ pageTitle }}</p>
-    <p v-if="isLogin" class="user">{{ user.username }} @{{ user.userId }}</p>
-    <nav v-else class="nav">
+    <!-- <p v-if="isLogin" class="user">{{ user.username }} @{{ user.userId }}</p> -->
+    <!-- <nav v-else class="nav">
       <nuxt-link to="/login">login</nuxt-link>
       <nuxt-link to="/signup">signup</nuxt-link>
-    </nav>
-    <p>{{ calcWinningPercentage(records) }} </p>
+    </nav> -->
+    <!-- <p>{{ calcWinningPercentage(records) }} </p> -->
   </div>
 </template>
 
 <script>
-import { calcWinningPercentage } from '@/utils/fighter.js'
+import { calcWinningPercentage } from '@/utils/records.js'
 
 export default {
   computed: {
@@ -33,7 +33,7 @@ export default {
           return '戦績一覧'
         }
         case 'analytics': {
-          return '分析'
+          return '戦績分析'
         }
         case 'mypage-id': {
           return 'マイページ'
@@ -51,7 +51,7 @@ export default {
           return 'ユーザ登録'
         }
         default: {
-          return 'すましす'
+          return 'Smashlytics'
         }
       }
     }
@@ -69,7 +69,7 @@ export default {
 .header {
   height: 60px;
   width: 100%;
-  background-color: #fafa7f;
+  background-color: #579aff;
   position: fixed;
   z-index: 10;
   top: 0;
@@ -85,7 +85,7 @@ export default {
 .page-title {
   font-size: 24px;
   font-weight: 600;
-  color: #4a5568d9;
+  color: #eaecf0;
 }
 .nav {
   display: flex;

--- a/components/Records.vue
+++ b/components/Records.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="records-table">
-    <div class="container mx-auto py-0 px-4">
+    <div class="mx-auto py-2 px-1">
       <div class="overflow-x-auto bg-white rounded-lg shadow overflow-y-auto relative" style="height: 100%;">
         <table class="border-collapse table-auto w-full whitespace-no-wrap bg-white table-striped relative">
           <thead>
             <tr class="text-left">
               <th
                 v-for="heading in headings" :key="heading.key"
-                class="bg-gray-100 sticky top-0 border-b border-gray-200 px-6 py-2 text-gray-600 font-bold tracking-wider uppercase text-xs"
+                class="bg-gray-100 sticky top-0 border-b border-gray-200 px-4 py-2 text-gray-600 font-bold tracking-wider uppercase text-xs"
               >{{ heading.value }}</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="record in records" :key="record.id">
               <td class="border-dashed border-t border-gray-200 px-3">
-                <span class="text-gray-700 px-6 py-3 flex items-center">{{ timestamp2dateString(record.createdAt) }}</span>
+                <span class="text-gray-700 px-1 py-3 flex items-center">{{ record.createdAt.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }).slice(0, 5) }}</span>
               </td>
               <td class="border-dashed border-t border-gray-200">
                 <FighterIcon :fighterId="record.fighterId" size="32px" />
@@ -23,14 +23,14 @@
                 <FighterIcon :fighterId="record.opponentId" size="32px" />
               </td>
               <td class="border-dashed border-t border-gray-200">
-                <span class="text-gray-700 px-6 py-3 flex items-center">{{ bool2result(record.result) }}</span>
+                <span class="text-gray-700 px-3 py-3 flex items-center">{{ bool2result(record.result) }}</span>
               </td>
               <td class="border-dashed border-t border-gray-200">
-                <span class="text-gray-700 px-6 py-3 flex items-center">{{ record.globalSmashPower }}</span>
+                <span class="text-gray-700 px-3 py-3 flex items-center">{{ record.globalSmashPower }}</span>
               </td>
-              <td class="border-dashed border-t border-gray-200">
-                <span class="text-gray-700 px-6 py-3 flex items-center" x-text="record.stage">{{ jpStageName(record.stage) }}</span>
-              </td>
+              <!-- <td class="border-dashed border-t border-gray-200">
+                <span class="text-gray-700 px-3 py-3 flex items-center" x-text="record.stage">{{ jpStageName(record.stage) }}</span>
+              </td> -->
             </tr>
           </tbody>
         </table>
@@ -40,7 +40,6 @@
 </template>
 
 <script>
-import { timestamp2dateString } from '@/utils/date.js'
 import FighterIcon from '@/components/FighterIcon.vue'
 
 export default {
@@ -79,10 +78,10 @@ export default {
         {
           key: 'globalSmashPower',
           value: '世界戦闘力'
-        },
-        {
-          key: 'stage',
-          value: 'ステージ'
+        // },
+        // {
+        //   key: 'stage',
+        //   value: 'ステージ'
         }
       ],
       stages: {
@@ -106,13 +105,18 @@ export default {
     fighterIconPath(fighterId){
       const fighterEnName = this.fighters[fighterId].name_en
       return ''
-    },
-    timestamp2dateString
+    }
   }
 }
 </script>
 
 <style scoped lang="scss">
+.records-table {
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  // align-items: center;
+}
 ul {
   display: flex;
   flex-direction: column;

--- a/pages/analytics.vue
+++ b/pages/analytics.vue
@@ -57,7 +57,7 @@
 
 <script>
 import { timestamp2date, now, today } from '@/utils/date.js'
-import { calcWinningPercentage } from '@/utils/fighter.js'
+import { calcWinningPercentage } from '@/utils/records.js'
 import FighterIcon from '@/components/FighterIcon.vue'
 
 export default {
@@ -124,9 +124,9 @@ export default {
       const specificRecords = this.getRecordsByFighters(fighterId, opponentId)
       return calcWinningPercentage(specificRecords)
     },
-    inPeriod(timestamp, period) {
+    inPeriod(date, period) {
       const targetDate = new Date(this.today.getFullYear(), this.today.getMonth(), this.today.getDate() - Number(period))
-      return timestamp2date(timestamp) > targetDate
+      return date > targetDate
     },
     calcWinningPercentage,
     timestamp2date

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,19 +33,11 @@ export default {
   },
   data() {
     return {
-      record: {
-        fighter: 'ロイ',
-        opponent: '',
-        result: true,
-        globalSmashPower: null,
-        stage: null
-      },
-      error: '',
       isShowModal: false,
-      userId: 'andmohiko',
       now: now()
     }
   },
+  watch: {},
   computed: {
     records() {
       return this.$store.state.records
@@ -54,8 +46,8 @@ export default {
       return this.$store.state.fighters
     },
     resultsToday() {
-      const today = new Date(this.now).toLocaleString({ timeZone: 'Asia/Tokyo' }).slice(0, 10).replaceAll('/', '-')
-      const recordsToday = this.records.filter(record => timestamp2dateString(record.createdAt) === today)
+      const today = new Date(this.now).toLocaleString({ timeZone: 'Asia/Tokyo' }).slice(0, 10)
+      const recordsToday = this.records.filter(record => record.createdAt.toLocaleString({ timeZone: 'Asia/Tokyo' }).slice(0, 10) === today)
       const wins = recordsToday.filter(record => record.result).length
       const loses = recordsToday.length - wins
       return wins + '勝' + loses + '敗'
@@ -67,9 +59,6 @@ export default {
     }
   },
   methods: {
-    async getRecords() {
-      await this.$store.dispatch('getRecords', this.userId)
-    },
     openModal() {
       this.isShowModal = true
     },
@@ -86,7 +75,7 @@ export default {
   min-height: calc(100vh - 110px);
   display: flex;
   flex-direction: column;
-  // justify-content: center;
+  justify-content: center;
   align-items: center;
   text-align: center;
 }
@@ -110,7 +99,7 @@ export default {
 }
 .records {
   margin: 0 50px;
-  width: 500px;
+  // width: 500px;
   display: flex;
   flex-direction: column;
   // justify-content: center;

--- a/pages/mypage/_id.vue
+++ b/pages/mypage/_id.vue
@@ -11,9 +11,10 @@
     <div>
       <p class="title">過去の戦績登録</p>
       <Button @onClick="toHistory" label="登録する" />
+      <Button @onClick="toSumHistory" label="一括登録する" />
     </div>
     <div>
-      <p class="title">ログイン・ログアウト</p>
+      <p class="title">ログイン/ログアウト</p>
       <Button @onClick="login" label="googleでログイン" />
       <Button @onClick="logout" label="ログアウト" />
     </div>
@@ -24,7 +25,7 @@
 // import { firebase, firestore, serverTimestamp } from '@/plugins/firebase'
 import firebase from '@/plugins/firebase'
 import Button from '@/components/Button.vue'
-import { calcWinningPercentage } from '@/utils/fighter.js'
+import { calcWinningPercentage } from '@/utils/records.js'
 import Cookies from "universal-cookie"
 
 export default {
@@ -46,9 +47,6 @@ export default {
     },
     records() {
       return this.$store.state.records
-    },
-    fighters() {
-      return this.$store.state.fighters
     },
     winningRate(fighter, opponent) {
       console.log(this.records)
@@ -80,6 +78,9 @@ export default {
     },
     toHistory () {
       this.$router.push("/history")
+    },
+    toSumHistory () {
+      this.$router.push("/sumhistory")
     },
     login() {
       this.$store.dispatch('loginGoogle')

--- a/store/index.js
+++ b/store/index.js
@@ -1,5 +1,6 @@
 import firebase from '@/plugins/firebase'
 import { setCookie } from '@/plugins/cookie'
+import { now } from '@/utils/date.js'
 
 const db = firebase.firestore()
 // import "firebase/auth"
@@ -40,7 +41,7 @@ const actions = {
       dispatch('getFighters')
     })
   },
-  async isUser({ commit, dispatch }, authId) {
+  async isUser({ dispatch }, authId) {
     const db = firebase.firestore()
     const authUser = await db
       .collection('authUsers')
@@ -79,11 +80,16 @@ const actions = {
     const records = await db
       .collection('records')
       .where("userId", "==", userId)
+      // .orderBy('createdAt', 'desc')
+      // .limit(docLength)
       .get()
       .then(querySnapshot => {
         let recordsArray = []
         querySnapshot.forEach(doc => {
-          recordsArray.push(doc.data())
+          let record = doc.data()
+          record.createdAt = record.createdAt.toDate()
+          record.updatedAt = record.updatedAt.toDate()
+          recordsArray.push(record)
         })
         return recordsArray.sort((a, b) => {
           return a.createdAt > b.createdAt ? -1 : 1
@@ -108,6 +114,13 @@ const actions = {
         console.log("Error getting document:", error);
       })
     commit('setFighters', fighters)
+  },
+  addRecords ({ commit, state }, newRecord) {
+    newRecord.createdAt = new Date(now())
+    newRecord.updatedAt = new Date(now())
+    let recordsUnshifted = state.records.slice()
+    recordsUnshifted.unshift(newRecord)
+    commit('setRecords', recordsUnshifted)
   }
 }
 

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,7 +1,9 @@
 export function timestamp2dateString(timestamp) {
   if (!timestamp) return 'N/A'
   const date = timestamp.toDate()
-  return date.getFullYear() + '-' + (date.getMonth()+1) + '-' + date.getDate()
+  return date.getDate() < 10 ?
+    date.getFullYear() + '/' + (date.getMonth()+1) + '/0' + date.getDate() :
+    date.getFullYear() + '/' + (date.getMonth()+1) + '/' + date.getDate()
 }
 
 export function timestamp2date(timestamp) {

--- a/utils/records.js
+++ b/utils/records.js
@@ -1,12 +1,3 @@
-export function en2jp(fighterEn, fighters) {
-  return fighters[fighterEn].name
-}
-
-export function jp2id(fighterJp, fighters) {
-  const fighter = Object.values(fighters).filter(f => f.name === fighterJp)[0]
-  return fighter.fighterId
-}
-
 export function calcWinningPercentage(records) {
   const wins = records.filter(record => record.result).length
   const loses = records.length - wins


### PR DESCRIPTION
## 概要

戦績登録するたびにrecordsを取得しないようにし、
新しく登録したrecordはstore内で追加する。
それに伴いVuexに保存するrecordsの createdAt と updateAt の型を
timestamp方からdate型に変更する。

### 経緯

新たな戦績(record)を登録するたびにfirestoreからrecordsを全件取得していたが、
これだとread回数が多くなるのでこの取得をやめたい。
そこで新たに登録した戦績をstoreのrecordsにも追加してstoreを更新する。
このときに、documentをcreateするときにはtimestamp型を使うところ(createdAt と updateAt は)を
storeにはdate型を使う。

この変更で副次的に戦績一覧の再描画も解決された。

## 変更内容

- 新たに戦績を登録するときにrecordsを取得しない
  - storeのrecordsに直接追加してstoreを更新する
- storeでsetRecordsするときに createdAt と updateAt をdate型にする
- 日付表示する箇所で型の変更に対応