### PR TITLE
マイページを開けないエラー

### DIFF
--- a/pages/_id.vue
+++ b/pages/_id.vue
@@ -39,10 +39,16 @@ export default {
         isPrivateAccount: false
       }
     }
-
-    const pageUserId = route.path.replaceAll('/', '')
     // ユーザかどうか
     const myUserId = isLogin ? store.state.user.userId : null
+    let pageUserId = ''
+    try {
+      pageUserId = route.path.replaceAll('/', '')  
+    } catch(e) {
+      console.log('error at replacing /', e, route.path)
+      // route取得に失敗したのでマイページに飛ばすために自分のユーザIDを入れる
+      pageUserId = store.state.user.userId
+    }
 
     let pageData = {
       isMyUserPage: (myUserId === pageUserId)


### PR DESCRIPTION
## 概要

マイページを開くと画像のようなエラーになる人がいる
routeの取得に失敗して発生していると思われる

<img width="319" alt="スクリーンショット 2021-01-11 15 02 29" src="https://user-images.githubusercontent.com/39476524/104150689-0c79e800-541e-11eb-9d6c-9560d08d99dc.png">

## 変更内容

`route.path.replaceAll('/', '')` のエラーをcatchし、
無条件でユーザのマイページに飛ばすように変更した。

## レビューポイント

新たなバグを生み出さないかどうか