### PR TITLE
userの勝敗数のズレの修正

### DIFF
--- a/components/Mypage.vue
+++ b/components/Mypage.vue
@@ -23,7 +23,6 @@
           <FighterIcon :fighterId="record.fighterId" size="40px" />
           <span v-if="record.globalSmashPower" class="text-2xl text-gray-800">{{ record.globalSmashPower/10000 }}万</span>
           <span v-else class="text-2xl text-gray-800">--</span>
-          <!-- <span class="text-base text-gray-800">{{ winningPercentageByFighter(record.fighterId) }}</span> -->
         </div>
       </div>
 
@@ -87,7 +86,7 @@ import Button from '@/components/parts/Button.vue'
 import TwitterShareButton from '@/components/parts/TwitterShareButton.vue'
 import FighterIcon from '@/components/parts/FighterIcon.vue'
 import VoiceChat from '@/components/parts/VoiceChat.vue'
-import { userWinningPercentage, calcWinningPercentage } from '@/utils/records.js'
+import { userWinningPercentage } from '@/utils/records.js'
 import { logEvent } from '@/utils/analytics.js'
 
 export default {
@@ -142,11 +141,7 @@ export default {
     toNew() {
       this.$router.push("/new")
     },
-    userWinningPercentage,
-    winningPercentageByFighter(fighterId) {
-      const recordsByFighter = this.records.filter(record => record.fighterId === fighterId)
-      return calcWinningPercentage(recordsByFighter)
-    }
+    userWinningPercentage
   }
 }
 </script>

--- a/pages/analytics.vue
+++ b/pages/analytics.vue
@@ -51,7 +51,7 @@
       
       <p class="message">
         <span>{{ periodText }}の記録は {{ recordsFiltered.length }} 試合です。</span>
-        <span>({{ calcWinningPercentage(recordsFiltered) }})</span>
+        <span>({{ winningPercentageText(recordsFiltered) }})</span>
       </p>
       <div class="overflow-x-auto bg-white rounded-lg shadow overflow-y-auto relative" style="height: 100%;">
         <table class="border-collapse table-auto w-full whitespace-no-wrap bg-white table-striped relative">
@@ -158,10 +158,6 @@ export default {
         return record.fighterId === fighterId && record.opponentId === opponentId
       })
     },
-    winningPercentage(fighterId, opponentId) {
-      const specificRecords = this.getRecordsByFighters(fighterId, opponentId)
-      return calcWinningPercentage(specificRecords)
-    },
     inPeriod(date, period) {
       const targetDate = new Date(this.today.getFullYear(), this.today.getMonth(), this.today.getDate() - Number(period))
       return date > targetDate
@@ -169,7 +165,10 @@ export default {
     toggle() {
       return this.descending = !this.descending
     },
-    calcWinningPercentage
+    winningPercentageText(records) {
+      const results = calcWinningPercentage(records)
+      return results.wins + '勝' + results.loses + '敗 勝率' + results.percentage + '%'
+    }
   }
 }
 </script>

--- a/utils/records.js
+++ b/utils/records.js
@@ -10,5 +10,10 @@ export function calcWinningPercentage(records) {
   const wins = records.filter(record => record.result).length
   const loses = records.length - wins
   const percentage = records.length ? Math.round((wins/records.length)*100 * 10) / 10 : '--'
-  return wins + '勝' + loses + '敗 勝率' + percentage + '%'
+  return {
+    wins,
+    loses,
+    matches: records.length,
+    percentage
+  }
 }


### PR DESCRIPTION
## 概要

usersのdocumentに総合の勝敗数しているが、
戦績を編集・削除するとこれがずれることがある。
これを修正する。

## 変更内容

戦績を編集・削除するたびに全recordsから再計算するように変更した。


