### PR TITLE
バージョン取得は3分以上間隔をあける

### DIFF
--- a/middleware/version.js
+++ b/middleware/version.js
@@ -7,8 +7,7 @@ export default async function({ app, store }) {
   // 最新バージョン取得から3分以内なら更新しない
   const now = (new Date()).getTime()
   const version = store.state.version
-  console.log('refreshed', (now - version.refreshedAt) / 1000, 'secs before')
-  if ((now - version.refreshedAt) / 1000 < 60) return
+  if ((now - version.refreshedAt) / 1000 < 180) return
 
   try {
     const latestVersion = await db

--- a/middleware/version.js
+++ b/middleware/version.js
@@ -23,13 +23,13 @@ export default async function({ app, store }) {
         return Number(versionsArray[0])
       })
     console.log('now ver', version.versionNumber, 'latest ver', latestVersion)
-    // 期待するバージョン以上なら何もしない
-    if (latestVersion <= version.versionNumber) return
-    // 反映させるためにスーパーリロードを促す
     store.commit('setVersion', {
       versionNumber: latestVersion,
       refreshedAt: now
     })
+    // 期待するバージョン以上なら何もしない
+    if (latestVersion <= version.versionNumber) return
+    // 反映させるためにスーパーリロードを促す
     window.confirm('新しいバージョンが配信されているため最新バージョンに更新します。')
     location.reload(true)
   } catch(error) {

--- a/store/index.js
+++ b/store/index.js
@@ -25,7 +25,10 @@ const state = {
     noticeType: null,
     message: ''
   },
-  version: 0
+  version: {
+    versionNumber: 0,
+    refreshedAt: null
+  }
 }
 
 const actions = {


### PR DESCRIPTION
- 現状はページ遷移のたびにバージョンの取得をしている
- read回数を削減するために最新バージョンのreadは3分以上間隔をあける
  - 最新の取得日時をstoreに保存する