### PR TITLE
戦績にストック数入力を追加

### DIFF
--- a/components/modals/AddArenaRecordModal.vue
+++ b/components/modals/AddArenaRecordModal.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="modal-bg">
     <div class="record-modal bg-white shadow-md rounded px-4 pt-6 pb-8 mb-4 flex flex-col overflow-auto">
-      <div class="close" @click="onClose">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+      <div class="modal-header">
+        <div class="close" @click="onClose">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <h2 class="text-xl py-2 border-b">専用部屋の戦績を登録する</h2>
       </div>
-      <div class="form">
-        <h2 class="text-xl py-2 border-b mb-4">専用部屋の戦績を登録する</h2>
+      <div class="modal-content pt-2 overflow-auto">
         <p class="error">{{ error }}</p>
         <div class="fighter-selecter">
           <FighterSelecter
@@ -29,16 +31,19 @@
             label="相手のファイター"
           />
         </div>
-        <ResultButton @clickWin="isWin" @clickLose="isLose" class="pt-4 pb-2" />
         
         <div v-show="isShowInputDetails" class="details mt-20 mb-20 px-4">
           <span class="text-gray-700 px-1 pt-3 flex items-center">▼詳しく記録したい人向け</span>
           <span class="text-gray-600 text-xs px-1 pb-3 flex items-center">入力しておくとあとで詳しく分析できるよ！</span>
-          <StageSelecter ref="stage" :isShowSmamateStages="true" :previousSelect="lastRecord.stage" :isShowOptionEmpty="false" />
+          <StageSelecter ref="stage" :isShowSmamateStages="true" :previousSelect="lastRecord.stage" />
           <AgainstSelecter ref="againstSelect" :fightedPlayers="fightedPlayers" :previousSelect="''" />
           <span class="text-gray-700 text-sm">名前を入力する</span>
-          <TextField ref="againstText" label="対戦相手" :isLabelShow="false" placeholder="はじめて対戦した人なら入力してね" />
+          <TextField ref="againstText" label="対戦相手" :isLabelShow="false" placeholder="はじめて対戦した人なら入力してね" class="pb-2"/>
+          <StocksSelecter ref="stocksSelecter" :defaultValue="lastRecord.stocks" />
         </div>
+      </div>
+      <div class="modal-footer border-t pt-2">
+        <ResultButton @clickWin="isWin" @clickLose="isLose" class="pb-4" />
         <div class="submit">
           <Button @onClick="submit" label="登録する" />
         </div>
@@ -54,6 +59,7 @@ import Button from '@/components/parts/Button.vue'
 import ResultButton from '@/components/parts/ResultButton.vue'
 import FighterSelecter from '@/components/parts/FighterSelecter.vue'
 import StageSelecter from '@/components/parts/StageSelecter.vue'
+import StocksSelecter from '@/components/parts/StocksSelecter.vue'
 import AgainstSelecter from '@/components/parts/AgainstSelecter.vue'
 import fighters from '@/assets/fighters.json'
 import { logEvent } from '@/utils/analytics.js'
@@ -76,6 +82,7 @@ export default {
     TextField,
     FighterSelecter,
     StageSelecter,
+    StocksSelecter,
     AgainstSelecter
   },
   data() {
@@ -151,7 +158,8 @@ export default {
         opponentId: this.record.opponentId,
         result: this.record.result,
         stage: this.$refs.stage.input,
-        against
+        against,
+        stocks: this.$refs.stocksSelecter.stocks
       }
       const updateUserDto = {
         resultsArena: {

--- a/components/modals/AddRecordModal.vue
+++ b/components/modals/AddRecordModal.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="modal-bg">
     <div class="record-modal bg-white shadow-md rounded px-4 pt-6 pb-8 mb-4 flex flex-col overflow-auto">
-      <div class="close" @click="onClose">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+      <div class="modal-header">
+        <div class="close" @click="onClose">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <h2 class="text-xl py-2 border-b">オンラインの戦績を登録する</h2>
       </div>
-      <div class="form">
-        <h2 class="text-xl py-2 border-b mb-4">オンラインの戦績を登録する</h2>
+      <div class="modal-content pt-2 overflow-auto">
         <p class="error">{{ error }}</p>
         <div class="fighter-selecter">
           <FighterSelecter
@@ -29,16 +31,19 @@
             label="相手のファイター"
           />
         </div>
-        <ResultButton @clickWin="isWin" @clickLose="isLose" class="pt-4 pb-2" />
         
         <div v-show="isShowInputDetails" class="details mt-20 mb-20 px-4">
           <span class="text-gray-700 px-1 pt-3 flex items-center">▼詳しく記録したい人向け</span>
           <span class="text-gray-600 text-xs px-1 pb-3 flex items-center">入力しておくとあとで詳しく分析できるよ！</span>
           <TextField ref="globalSmashPower" :allowEmpty="false" label="世界戦闘力(万)" placeholder="例: 678万くらい → 678" />
           <StageSelecter ref="stage" :isShowOptionEmpty="false" />
+          <StocksSelecter ref="stocksSelecter" :isShowOptionEmpty="false" />
           <Checkbox ref="isRepeat" label="連戦だった" />
           <Checkbox ref="isVip" :defaultValue="lastRecord.isVip" label="VIPマッチ" />
         </div>
+      </div>
+      <div class="modal-footer border-t pt-2">
+        <ResultButton @clickWin="isWin" @clickLose="isLose" class="pb-4" />
         <div class="submit">
           <Button @onClick="submit" label="登録する" />
         </div>
@@ -54,6 +59,7 @@ import Button from '@/components/parts/Button.vue'
 import ResultButton from '@/components/parts/ResultButton.vue'
 import FighterSelecter from '@/components/parts/FighterSelecter.vue'
 import StageSelecter from '@/components/parts/StageSelecter.vue'
+import StocksSelecter from '@/components/parts/StocksSelecter.vue'
 import Checkbox from '@/components/input/Checkbox.vue'
 import fighters from '@/assets/fighters.json'
 import { logEvent } from '@/utils/analytics.js'
@@ -76,6 +82,7 @@ export default {
     TextField,
     FighterSelecter,
     StageSelecter,
+    StocksSelecter,
     Checkbox
   },
   data() {
@@ -144,6 +151,7 @@ export default {
         result: this.record.result,
         stage: this.$refs.stage.input,
         globalSmashPower: this.record.globalSmashPower ? Number(this.record.globalSmashPower) * 10000 : null,
+        stocks: this.$refs.stocksSelecter.stocks,
         isRepeat: this.$refs.isRepeat.input,
         isVip: this.$refs.isVip.input
       }

--- a/components/modals/EditArenaRecordModal.vue
+++ b/components/modals/EditArenaRecordModal.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="modal-bg">
     <div class="record-modal bg-white shadow-md rounded px-4 pt-6 pb-8 mb-4 flex flex-col overflow-auto">
-      <div class="close" @click="onClose">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+      <div class="modal-header">
+        <div class="close" @click="onClose">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <h2 class="text-xl py-2 border-b">戦績を更新する</h2>
       </div>
-      <div class="form">
-        <h2 class="text-xl py-2 border-b mb-4">戦績を更新する</h2>
+      <div class="modal-content pt-2 overflow-auto">
         <p class="error">{{ error }}</p>
         <div class="fighter-selecter">
           <FighterSelecter
@@ -42,12 +44,15 @@
           />
           <AgainstSelecter ref="againstSelect" :fightedPlayers="fightedPlayers" :previousSelect="editingRecord.against" />
           <span class="text-gray-700 text-sm">名前を入力する</span>
-          <TextField ref="againstText" label="対戦相手" :isLabelShow="false" placeholder="はじめて対戦した人なら入力してね" />
+          <TextField ref="againstText" label="対戦相手" :isLabelShow="false" placeholder="はじめて対戦した人なら入力してね" class="pb-2" />
+          <!-- <StocksSelecter ref="stocksSelecter" :defaultValue="editingRecord.stocks" /> -->
         </div>
-        <div class="pb-4">
+      </div>
+      <div class="modal-footer border-t pt-2">
+        <div class="pb-1">
           <Button @onClick="updateRecord" label="更新する" />
         </div>
-        <div class="pt-4">
+        <div class="pt-1">
           <Button @onClick="deleteRecord" label="削除する" />
         </div>
       </div>
@@ -62,6 +67,7 @@ import Button from '@/components/parts/Button.vue'
 import ResultButton from '@/components/parts/ResultButton.vue'
 import FighterSelecter from '@/components/parts/FighterSelecter.vue'
 import StageSelecter from '@/components/parts/StageSelecter.vue'
+import StocksSelecter from '@/components/parts/StocksSelecter.vue'
 import AgainstSelecter from '@/components/parts/AgainstSelecter.vue'
 import Checkbox from '@/components/input/Checkbox.vue'
 import { now, date2string } from '@/utils/date.js'
@@ -87,6 +93,7 @@ export default {
     TextField,
     FighterSelecter,
     StageSelecter,
+    StocksSelecter,
     AgainstSelecter,
     Checkbox
   },
@@ -153,7 +160,8 @@ export default {
         opponentId: this.editingRecord.opponentId,
         result: this.editingRecord.result,
         stage: this.$refs.stage.input,
-        against
+        against,
+        stocks: this.$refs.stocksSelecter.stocks
       }
       const db = firebase.firestore()
       try {

--- a/components/modals/EditRecordModal.vue
+++ b/components/modals/EditRecordModal.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="modal-bg">
     <div class="record-modal bg-white shadow-md rounded px-4 pt-6 pb-8 mb-4 flex flex-col overflow-auto">
-      <div class="close" @click="onClose">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+      <div class="modal-header">
+        <div class="close" @click="onClose">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 18L18 6M6 6L18 18" stroke="#4A5568" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <h2 class="text-xl py-2 border-b">戦績を更新する</h2>
       </div>
-      <div class="form">
-        <h2 class="text-xl py-2 border-b mb-4">戦績を更新する</h2>
+      <div class="modal-content pt-2 overflow-auto">
         <p class="error">{{ error }}</p>
         <div class="fighter-selecter">
           <FighterSelecter
@@ -36,13 +38,16 @@
           <span class="text-gray-600 text-xs px-1 pb-3 flex items-center">入力しておくとあとで詳しく分析できるよ！</span>
           <!-- <TextField ref="globalSmashPower" :allowEmpty="false" :defaultValue="String(editingRecord.globalSmashPower/10000)" label="世界戦闘力(万)" placeholder="例: 678万くらい → 678" /> -->
           <StageSelecter ref="stage" :previousSelect="editingRecord.stage" />
+          <StocksSelecter ref="stocksSelecter" :defaultValue="editingRecord.stocks" />
           <Checkbox ref="isRepeat" :defaultValue="editingRecord.isRepeat" label="連戦だった" />
           <Checkbox ref="isVip" :defaultValue="editingRecord.isVip" label="VIPマッチ" />
         </div>
-        <div class="pb-4">
+      </div>
+      <div class="modal-footer border-t pt-2">
+        <div class="pb-1">
           <Button @onClick="updateRecord" label="更新する" />
         </div>
-        <div class="pt-4">
+        <div class="pt-1">
           <Button @onClick="deleteRecord" label="削除する" />
         </div>
       </div>
@@ -57,6 +62,7 @@ import Button from '@/components/parts/Button.vue'
 import ResultButton from '@/components/parts/ResultButton.vue'
 import FighterSelecter from '@/components/parts/FighterSelecter.vue'
 import StageSelecter from '@/components/parts/StageSelecter.vue'
+import StocksSelecter from '@/components/parts/StocksSelecter.vue'
 import Checkbox from '@/components/input/Checkbox.vue'
 import { now, date2string } from '@/utils/date.js'
 import { calcWinningPercentage } from '@/utils/records.js'
@@ -82,6 +88,7 @@ export default {
     TextField,
     FighterSelecter,
     StageSelecter,
+    StocksSelecter,
     Checkbox
   },
   data() {
@@ -136,6 +143,7 @@ export default {
         opponentId: this.editingRecord.opponentId,
         result: this.editingRecord.result,
         stage: this.$refs.stage.input,
+        stocks: this.$refs.stocksSelecter.stocks,
         isRepeat: this.$refs.isRepeat.input,
         isVip: this.$refs.isVip.input
       }

--- a/components/parts/StocksSelecter.vue
+++ b/components/parts/StocksSelecter.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="w-full text-gray-700">
+    <p class="text-base text-left pb-1 pl-1">ストック数</p>
+    <!-- <div class="flex flex-col justify-center items-center"> -->
+    <div>
+      <p class="text-sm text-left pb-1 pl-1">試合のルール</p>
+      <form class="mb-2 px-2 flex flex-wrap justify-start items-center">
+        <div class="option pb-1">
+          <input
+            id="stocks-2"
+            v-model="stocks.rule"
+            type="radio"
+            name="2"
+            :value="'2'"
+          />
+          <label for="stocks-2" class="pr-2 whitespace-nowrap">2スト</label>
+        </div>
+        <div class="option pb-1">
+          <input
+            id="stocks-3"
+            v-model="stocks.rule"
+            type="radio"
+            name="3"
+            :value="'3'"
+          />
+          <label for="stocks-3" class="pr-2 whitespace-nowrap">3スト</label>
+        </div>
+        <!-- <div class="option pb-1">
+          <input
+            id="stocks-other"
+            v-model="stocks.rule"
+            type="radio"
+            name="other"
+            :value="null"
+          />
+          <label for="stocks-other" class="pr-2 whitespace-nowrap">その他</label>
+        </div> -->
+        <!-- textbox -->
+        <div v-if="isShowOptionEmpty" class="option pb-1">
+          <input
+            id="stocks-empty"
+            v-model="stocks.rule"
+            type="radio"
+            name="null"
+            :value="null"
+          />
+          <label for="stocks-null" class="pr-2">登録しない</label>
+        </div>
+      </form>
+    </div>
+    <!-- <div class="custom-number-input">
+      <label for="custom-input-number" class="text-gray-700 text-sm">試合結果</label>
+      <Checkbox ref="" label="撃墜した数も記録する" />
+      <span class="text-gray-600 text-xs px-1 pb-3 flex items-center">どれくらい優勢/劣勢だったかも分析できるようになるよ！</span>
+      <div class="flex flex-row h-10 w-full rounded-lg relative bg-transparent mt-1 items-center text-center ">
+        <button @click="decrement" class=" bg-gray-300 text-gray-600 hover:text-gray-700 hover:bg-gray-400 h-8 w-8 rounded-l cursor-pointer outline-none">
+          <span class="m-auto text-2xl font-thin">−</span>
+        </button>
+        <label class="text-gray-700">{{ stocksTaken }}</label>
+        <button @click="increment" class="bg-gray-300 text-gray-600 hover:text-gray-700 hover:bg-gray-400 h-full w-20 rounded-r cursor-pointer">
+          <span class="m-auto text-2xl font-thin">+</span>
+        </button>
+      </div>
+    </div> -->
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    defaultValue: {
+      required: false,
+      type: Object
+    },
+    isShowOptionEmpty: {
+      default: true,
+      type: Boolean
+    }
+  },
+  data() {
+    return {
+      stocks: {
+        rule: null,
+        player: null,
+        opponent: null
+      }
+    }
+  },
+  mounted() {
+    if (!this.defaultValue) return
+    this.stocks = this.defaultValue
+  },
+  methods: {
+    get() {
+      return {
+        stocks: this.stocks
+      }
+    },
+    increment() {
+      this.stocks.player += 1
+    },
+    decrement() {
+      if (this.stocks.player <= 0) return
+      this.stocks.player -= 1
+    }
+
+  }
+}
+</script>
+
+<style lang="scss">
+</style>


### PR DESCRIPTION
## 実装したもの

- StocksSelecterを追加
- オンラインと専用部屋の戦績登録でルールのストック数を入力できる
- オンラインの戦績編集でストック数を編集可能


### 未実装
- 専用部屋の戦績編集でストック数を編集
- 分析でストック数ごとの絞り込み
- お互いに何ストック落としたかの記録