### PR TITLE
デフォルトで表示する戦績数を減らす

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -58,6 +58,9 @@
         </div>
       </div>
     </div>
+    <div class="pt-2" v-if="!isShowAllRecords">
+      <Button @onClick="showAllRecords" label="戦績をもっと表示する" />
+    </div>
     
     <p class="error text-xl py-2 mb-4 text-red-700">{{ error }}</p>
     <div v-show="error" class="border-b">
@@ -98,6 +101,7 @@ export default {
       headings: ['日付','自分','相手','勝敗','編集'],
       editingRecord: {},
       now: now(),
+      isShowAllRecords: false,
       error: ''
     }
   },
@@ -112,7 +116,10 @@ export default {
       return this.$store.state.user
     },
     records() {
-      return this.$store.state.records.filter(record => record.roomType !== 'arena')
+      if (this.isShowAllRecords) {
+        return this.$store.state.records.filter(record => record.roomType !== 'arena')
+      }
+      return this.$store.state.records.filter(record => record.roomType !== 'arena').slice(0, 30)
     },
     isLogin() {
       return Boolean(this.$store.state.user.userId)
@@ -132,6 +139,9 @@ export default {
     }
   },
   methods: {
+    showAllRecords() {
+      this.isShowAllRecords = true
+    },
     openAddModal() {
       this.error = ''
       if (!this.isLogin) {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -47,6 +47,12 @@
       <div class="bg-white shadow-md rounded px-8 pt-2 pb-6 mb-4 flex flex-col">
         <h2 class="text-xl mb-4">Release notes</h2>
         <div class="version text-left mb-4">
+          <h3 class="text-base">Ver 4.0.2</h3>
+          <ul class="text-sm">
+            <li>◎デフォルトで表示する戦績数を30件に変更</li>
+          </ul>
+        </div>
+        <div class="version text-left mb-4">
           <h3 class="text-base">Ver 4.0.1</h3>
           <ul class="text-sm">
             <li>◎専用部屋機能のメニューを設定画面に追加</li>
@@ -200,7 +206,7 @@
       </div>
       <Button @onClick="logout" label="ログアウト" />
       <div class="flex justify-end text-sm text-gray-500 pt-6 pr-2">
-        Version 4.0.1
+        Version 4.0.2
       </div>
       <div class="copyright">
         <p>


### PR DESCRIPTION
close #42 

- 戦績数が多い人は画面が重い
- デフォルトだと最新30件のみ表示し、戦績一覧の下部から全件表示できるように変更